### PR TITLE
Log listened port on the console

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,5 +14,5 @@ router.db._.id = 'isbn'
 server.use(router)
 const port = process.env.PORT || 4730
 server.listen(port, function () {
-  console.log('JSON Server is running')
+  console.log(`JSON Server is running on port ${port}`)
 })


### PR DESCRIPTION
The port which the server listens on isn’t logged to the console, which makes it difficult for workshop participants to identify which port to use.