### PR TITLE
fix banner path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmonkey-api",
   "description": "A simple backend for the BookMonkey example application.",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "compose-middleware": "^5.0.1",

--- a/server.js
+++ b/server.js
@@ -5,8 +5,9 @@ const guards = require('./middlewares/guards.js')
 const bookValidation = require('./middlewares/book-validation.js')
 const users = require('./users.js')
 const fs = require('fs')
+const path = require('path')
 
-console.log(fs.readFileSync('./banner.txt', {encoding: "ascii"}))
+console.log(fs.readFileSync(path.join(__dirname, 'banner.txt'), {encoding: "ascii"}))
 
 const server = jsonServer.create()
 const router = jsonServer.router(__dirname + '/db.json')


### PR DESCRIPTION
Pawel Sawicki
@Toni und @Trainer:innen  in der bookmonkey-api gibt es schon seit 2 Wochen folgenden Bug beim Erstaufruf: Es fehlt die banner.txt. Der Fix ist, dass die betroffenen Teilnehmer im Verzeichnis, wo sie die bookmonkey-api aufrufen die banner.txt händisch erstellen... dann funktioniert alles.

